### PR TITLE
Bugfixes for signature verification with native secp256k1 library

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -705,7 +705,7 @@ public class ECKey implements EncryptableItem {
 
         if (Secp256k1Context.isEnabled()) {
             try {
-                return NativeSecp256k1.verify(data, signature.encodeToDER(), pub);
+                return NativeSecp256k1.verify(data, signature.toCanonicalised().encodeToDER(), pub);
             } catch (NativeSecp256k1Util.AssertFailException e) {
                 log.error("Caught AssertFailException inside secp256k1", e);
                 return false;
@@ -733,14 +733,6 @@ public class ECKey implements EncryptableItem {
      * @param pub       The public key bytes to use.
      */
     public static boolean verify(byte[] data, byte[] signature, byte[] pub) {
-        if (Secp256k1Context.isEnabled()) {
-            try {
-                return NativeSecp256k1.verify(data, signature, pub);
-            } catch (NativeSecp256k1Util.AssertFailException e) {
-                log.error("Caught AssertFailException inside secp256k1", e);
-                return false;
-            }
-        }
         return verify(data, ECDSASignature.decodeFromDER(signature), pub);
     }
 


### PR DESCRIPTION
Calling verify(byte[], ECDSASignature, byte[]) with the native secp256k1 library would fail on non-canonicalized (not low-S) signatures. The Java counterpart ECDSASigner.verifySignature() allows non-canonical signatures. When relaying and mining, non-canonical signatures are not allowed, but this is checked for in TransactionSignature.decodeFromBitcoin(). The fix is to canonicalize the signature.

Calling verify(byte[], byte[], byte[]) with the native secp256k1 library would ignore the FAKE_SIGNATURES flag. Since this method also needs to allow low-S signatures, it has been modified to instead chain to verify(byte[], ECDSASignature, byte[]).

To improve native performance, it would be best if the canonicalizing happened in the native library via secp256k1_ecdsa_signature_normalize(ctx, &sig, &sig). However, it would require an API change in both bitcoinj and secp256k1 because the expected behavior in secp256k1 is to fail non-normalized signatures (this is evident in their testing suite). The API change could be either a normalization flag passed to the verify method, or a new method (normalize a byte[] signature).
